### PR TITLE
Adding additional features for cluster management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
-	github.com/xanzy/go-gitlab v0.20.1
+	github.com/xanzy/go-gitlab v0.20.2-0.20191016170832-cb3b2d5c6384
 	k8s.io/api v0.0.0-20190831074750-7364b6bdad65
 	k8s.io/apimachinery v0.0.0-20190831074630-461753078381
 	k8s.io/cli-runtime v0.0.0-20190831080432-9d670f2021f4

--- a/go.sum
+++ b/go.sum
@@ -149,9 +149,12 @@ github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xanzy/go-gitlab v0.20.1 h1:+1BWDry84G5PzsnzG9DI4YjPbHeWKyouM0q0gfDPKgY=
 github.com/xanzy/go-gitlab v0.20.1/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
+github.com/xanzy/go-gitlab v0.20.2-0.20191016170832-cb3b2d5c6384 h1:MKJkWNdieurL84u8bfqBLYKoklAX+3OG9TTxbE6AWrs=
+github.com/xanzy/go-gitlab v0.20.2-0.20191016170832-cb3b2d5c6384/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/cmd/gitlab-bootstrap.go
+++ b/pkg/cmd/gitlab-bootstrap.go
@@ -29,9 +29,10 @@ const Version = "1.0.0"
 type GitLabBootstrapOptions struct {
 	ConfigFlags *genericclioptions.ConfigFlags
 
-	GitLabAPIToken  string
-	GitLabProjectID string
-	GitLabURL       string
+	GitLabAPIToken     string
+	GitLabProjectID    string
+	GitLabURL          string
+	GitLabGroupCluster bool
 
 	KubeConfig    string
 	RestConfig    *restclient.Config
@@ -81,6 +82,7 @@ func NewCmdGitLabBootstrap(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.Flags().StringVar(&o.GitLabAPIToken, "gitlab-api-token", "", "Private token from GitLab. Pulled from env[\"GITLAB_API_TOKEN\"] if not provided")
 	cmd.Flags().StringVar(&o.GitLabURL, "gitlab-url", "", "Set to override default connection to GitLab")
+	cmd.Flags().BoolVar(&o.GitLabGroupCluster, "gitlab-use-group", false, "Add the cluster to the group identified by the id rather than a project")
 	o.ConfigFlags.AddFlags(cmd.Flags())
 
 	return cmd
@@ -153,9 +155,16 @@ func (o *GitLabBootstrapOptions) Validate() error {
 		o.GitLabAPI.SetBaseURL(o.GitLabURL)
 	}
 
-	_, _, err := o.GitLabAPI.Projects.GetProject(o.GitLabProjectID, nil)
-	if err != nil {
-		return errors.Wrap(err, "unable to get GitLab project")
+	if (o.GitLabGroupCluster) {
+		_, _, err := o.GitLabAPI.Groups.GetGroup(o.GitLabProjectID, nil)
+		if err != nil {
+			return errors.Wrap(err, "unable to get GitLab group")
+		}
+	} else {
+		_, _, err := o.GitLabAPI.Projects.GetProject(o.GitLabProjectID, nil)
+		if err != nil {
+			return errors.Wrap(err, "unable to get GitLab project")
+		}
 	}
 
 	return nil
@@ -172,7 +181,7 @@ func (o *GitLabBootstrapOptions) Run() error {
 	if err := o.SaveServiceAccountToken(); err != nil {
 		return err
 	}
-	if err := o.AddClusterToProject(); err != nil {
+	if err := o.AddClusterToGitLab(); err != nil {
 		return err
 	}
 	return nil
@@ -217,7 +226,7 @@ func (o *GitLabBootstrapOptions) CreateClusterRoleBinding() error {
 	} else {
 		fmt.Println("Using existing clusterrolebinding")
 	}
-	
+
 	return nil
 }
 
@@ -254,7 +263,41 @@ func (o *GitLabBootstrapOptions) SaveServiceAccountToken() error {
 }
 
 // AddClusterToProject adds the Kubernetes cluster to the GitLab project
-func (o *GitLabBootstrapOptions) AddClusterToProject() error {
+func (o *GitLabBootstrapOptions) AddClusterToGitLab() error {
+
+  if (o.GitLabGroupCluster) {
+		if err := o.addClusterToGroup(); err != nil {
+			return err
+		}
+	} else {
+		if err := o.addClusterToProject(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *GitLabBootstrapOptions) addClusterToGroup() error {
+	clusterOpts := &gitlab.AddGroupClusterOptions{
+		Name:             &o.ClusterName,
+		EnvironmentScope: gitlab.String("*"),
+		PlatformKubernetes: &gitlab.AddGroupPlatformKubernetesOptions{
+			APIURL: &o.ClusterHost,
+			Token:  &o.ServiceAccountToken,
+			CaCert: &o.ClusterCA,
+		},
+	}
+	gc, _, err := o.GitLabAPI.GroupCluster.AddCluster(o.GitLabProjectID, clusterOpts)
+	if err != nil {
+		return errors.Wrap(err, "unable to assign kubernetes cluster to group")
+	}
+	gitlabClusterURL := fmt.Sprintf("%s/clusters/%d", gc.Group.WebURL, gc.ID)
+	fmt.Println("Cluster successfully added to group!")
+	fmt.Printf("To finish up visit: %s and install Helm and Runner.\n", gitlabClusterURL)
+	return nil
+}
+
+func (o *GitLabBootstrapOptions) addClusterToProject() error {
 	clusterOpts := &gitlab.AddClusterOptions{
 		Name:             &o.ClusterName,
 		EnvironmentScope: gitlab.String("*"),
@@ -266,7 +309,7 @@ func (o *GitLabBootstrapOptions) AddClusterToProject() error {
 	}
 	pc, _, err := o.GitLabAPI.ProjectCluster.AddCluster(o.GitLabProjectID, clusterOpts)
 	if err != nil {
-		return errors.Wrap(err, "unable to add project to cluster")
+		return errors.Wrap(err, "unable to assign kubernetes cluster to project")
 	}
 	gitlabClusterURL := fmt.Sprintf("%s/clusters/%d", pc.Project.WebURL, pc.ID)
 	fmt.Println("Cluster successfully added to project!")


### PR DESCRIPTION
Adds two features for cluster management. The first is allowing
for the existence of previously created gitlab service account
and assigned role. The second is option to use a self-hosted
GitLab installation.